### PR TITLE
make the search for standard includes independent of locale settings

### DIFF
--- a/lib/compiler.rb
+++ b/lib/compiler.rb
@@ -46,7 +46,7 @@ module Compiler
 
       paths = []
       # Below is the recommended(!) way of getting standard serach paths from GCC
-      output = `echo | gcc -v -x #{ language } -E - 2>&1 1>/dev/null`
+      output = `echo | LANG=C gcc -v -x #{ language } -E - 2>&1 1>/dev/null`
       collecting = false
       output.each_line do | line |
         case


### PR DESCRIPTION
when setting the LANG to C, gcc always talks in english and the output can be reliable parsed
