### PR TITLE
add the prefix for cross compiler

### DIFF
--- a/lib/rake/builder.rb
+++ b/lib/rake/builder.rb
@@ -55,6 +55,9 @@ module Rake
     # processor type: 'i386', 'x86_64', 'ppc' or 'ppc64'.
     attr_accessor :architecture
 
+    # Prefix for cross comiler
+    attr_accessor :cross_compile
+
     # The programming language: 'c++', 'c' or 'objective-c' (default 'c++')
     # This also sets defaults for source_file_extension
     attr_accessor :programming_language
@@ -659,12 +662,12 @@ EOT
     def build_commands
       case @target_type
       when :executable
-        [ "#{ @linker } -o #{ @target } #{ file_list( object_files ) } #{ link_flags }" ]
+        [ "#{ @cross_compile }#{ @linker } -o #{ @target } #{ file_list( object_files ) } #{ link_flags }" ]
       when :static_library
-        [ "ar -cq #{ @target } #{ file_list( object_files ) }",
-          "ranlib #{ @target }" ]
+        [ "#{ @cross_compile }ar -cq #{ @target } #{ file_list( object_files ) }",
+          "#{ @cross_compile }ranlib #{ @target }" ]
       when :shared_library
-        [ "#{ @linker } -shared -o #{ @target } #{ file_list( object_files ) } #{ link_flags }" ]
+        [ "#{ @cross_compile }#{ @linker } -shared -o #{ @target } #{ file_list( object_files ) } #{ link_flags }" ]
       end
     end
 

--- a/lib/rake/builder.rb
+++ b/lib/rake/builder.rb
@@ -654,7 +654,7 @@ EOT
       @generated_files << object
       file object => [ source ] do |t|
         @logger.add( Logger::DEBUG, "Compiling '#{ source }'" )
-        command = "#{ @compiler } -c #{ compiler_flags } -o #{ object } #{ source }"
+        command = "#{ @cross_compile }#{ @compiler } -c #{ compiler_flags } -o #{ object } #{ source }"
         shell command
       end
     end

--- a/spec/crossprefix_spec.rb
+++ b/spec/crossprefix_spec.rb
@@ -1,0 +1,32 @@
+load File.dirname(__FILE__) + '/spec_helper.rb'
+
+describe 'when building a cross compilation project' do
+
+  include RakeBuilderHelper
+
+  before( :each ) do
+    Rake::Task.clear
+    @project = c_task( :executable )
+    @project.cross_compile = 'arm-none-eabi-'
+    class << @project
+      def commands
+        build_commands.to_s
+      end
+    end
+  end
+
+  it "respects the cross compilation prefix" do
+    @project.commands.should include("arm-none-eabi-gcc")
+  end
+
+  it "respects the prefix also for archive tools" do
+    @project.target_type = :static_library
+    @project.commands.should include("arm-none-eabi-ar")
+    @project.commands.should include("arm-none-eabi-ranlib")
+  end
+
+  it "builds a shared library with cross compiler" do
+    @project.target_type = :shared_library
+    @project.commands.should include("arm-none-eabi-gcc")
+  end
+end


### PR DESCRIPTION
new attribute: cross_compile
this is used as prefix to all build commands

For example, to compile a project for AVR set _builder.cross_compile = 'avr-'_
