### PR TITLE
local_config in combination with namespace

### DIFF
--- a/examples/05_tests/Rakefile
+++ b/examples/05_tests/Rakefile
@@ -14,6 +14,6 @@ Rake::Builder.new do |builder|
   builder.source_search_paths  = [ 'test', 'src/units.*' ]
   builder.header_search_paths  = [ 'include' ]
   builder.objects_path         = 'test'
-  builder.compilation_options  = '-DDEBUG'
+  builder.compilation_options  = [ '-DDEBUG' ]
 end
 

--- a/examples/05_tests/Rakefile
+++ b/examples/05_tests/Rakefile
@@ -5,14 +5,14 @@ require 'rake/builder'
 Rake::Builder.new do |builder|
   builder.target               = 'unit'
   builder.source_search_paths  = [ 'src' ]
-  builder.header_search_paths  = [ 'include' ]
+  builder.installable_headers  = [ 'include' ]
 end
 
 Rake::Builder.new do |builder|
   builder.task_namespace       = 'test'
   builder.target               = 'test_unit'
   builder.source_search_paths  = [ 'test', 'src/units.*' ]
-  builder.header_search_paths  = [ 'include' ]
+  builder.installable_headers  = [ 'include' ]
   builder.objects_path         = 'test'
   builder.compilation_options  = [ '-DDEBUG' ]
 end

--- a/examples/05_tests/include/units.h
+++ b/examples/05_tests/include/units.h
@@ -1,8 +1,8 @@
 #ifndef __UNITS_H__
 #define __UNITS_H__
 
-#include <ostream>;
-#include <string>;
+#include <ostream>
+#include <string>
 using namespace std;
 
 class Unit

--- a/lib/rake/builder/task_definers/builder_task_definer.rb
+++ b/lib/rake/builder/task_definers/builder_task_definer.rb
@@ -68,7 +68,7 @@ class Rake::Builder
         @builder.create_local_config
       end
 
-      once_task :load_local_config => scoped_task(@builder.local_config) do
+      once_task :load_local_config => @builder.local_config do
         @builder.load_local_config
       end
 

--- a/spec/unit/rake/builder/task_definers/builder_task_definer_spec.rb
+++ b/spec/unit/rake/builder/task_definers/builder_task_definer_spec.rb
@@ -129,6 +129,12 @@ describe Rake::Builder::BuilderTaskDefiner do
 
         expect(Rake::Task.task_defined?('foo')).to be_true
       end
+
+      it 'does not fiddle up the local_config file' do
+        subject.run
+
+        expect(Rake::Task['foo:load_local_config'].prerequisites).to eq([self.class.local_config])
+      end
     end
   end
 

--- a/spec/unit/rake/builder/task_definers/builder_task_definer_spec.rb
+++ b/spec/unit/rake/builder/task_definers/builder_task_definer_spec.rb
@@ -129,6 +129,12 @@ describe Rake::Builder::BuilderTaskDefiner do
 
         expect(Rake::Task.task_defined?('foo')).to be_true
       end
+
+      it 'defines the local_config task' do
+        subject.run
+
+        expect(Rake::Task.task_defined?('local_config')).to be_true
+      end
     end
   end
 

--- a/spec/unit/rake/builder/task_definers/builder_task_definer_spec.rb
+++ b/spec/unit/rake/builder/task_definers/builder_task_definer_spec.rb
@@ -129,12 +129,6 @@ describe Rake::Builder::BuilderTaskDefiner do
 
         expect(Rake::Task.task_defined?('foo')).to be_true
       end
-
-      it 'defines the local_config task' do
-        subject.run
-
-        expect(Rake::Task.task_defined?('local_config')).to be_true
-      end
     end
   end
 


### PR DESCRIPTION
Hi,
when trying out the example in 05_tests I stumbled about some issues:
- the compilation_options in Rakefile did not compile [62572da]
- the local_config file path was prepended with namespace, but no task exists

Also I replaced the deprecated header_search_paths with installable_headers [af66251] and fixed a g++ warning [4be43c3]
